### PR TITLE
feat: prevent navigation mark.

### DIFF
--- a/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.html
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.html
@@ -19,6 +19,16 @@
   >
     <mat-icon>delete_outline</mat-icon>
   </button>
+  <button
+    mat-icon-button
+    class="icon"
+    matTooltip="Mark to prevent navigation for this event"
+    matTooltipPosition="above"
+    aria-label="Prevent navigation"
+    (click)="preventNavigationSelected()"
+  >
+    <mat-icon>bookmark_border</mat-icon>
+  </button>
   <div class="spacer"></div>
   <mat-form-field appearance="outline" class="filter">
     <mat-label>Filter</mat-label>

--- a/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.ts
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table-toolbar/report-table-toolbar.component.ts
@@ -59,6 +59,10 @@ export class ReportTableToolbarComponent implements OnDestroy {
     this.dataSourceService.deleteSelected();
   }
 
+  preventNavigationSelected() {
+    this.dataSourceService.preventNavigationSelected();
+  }
+
   ngOnDestroy() {
     this.destroy$.next();
     this.destroy$.complete();

--- a/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.html
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.html
@@ -27,6 +27,11 @@
           style="text-decoration: none"
           [routerLink]="['./', element.eventName]"
           (click)="setReportDetails(element.eventName)"
+          matBadge="bookmark_border"
+          [matBadgeHidden]="
+            !preventNavigationEvents.includes(element.eventName)
+          "
+          matBadgeOverlap="false"
         >
           {{ element.eventName }}
         </a>

--- a/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.scss
+++ b/apps/ng-frontend/src/app/modules/project/components/report-table/report-table.component.scss
@@ -70,3 +70,7 @@ tr.example-element-row:not(.example-expanded-row):active {
 .false-status {
   color: red;
 }
+
+.mat-badge-content {
+  font-family: 'Material Icons'
+}

--- a/apps/ng-frontend/src/app/shared/services/api/settings/settings.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/api/settings/settings.service.ts
@@ -15,7 +15,6 @@ export class SettingsService {
   }
 
   getProjectSettings(projectSlug: string) {
-    console.log(`${environment.settingsApiUrl}/${projectSlug}`);
     return this.http.get<ProjectSetting>(
       `${environment.settingsApiUrl}/${projectSlug}`
     );

--- a/apps/ng-frontend/src/app/shared/services/project-data-source/project-data-source.service.ts
+++ b/apps/ng-frontend/src/app/shared/services/project-data-source/project-data-source.service.ts
@@ -10,6 +10,7 @@ export class ProjectDataSourceService extends DataSource<IReportDetails> {
   private _dataStream = new ReplaySubject<IReportDetails[]>();
   private _filterStream = new ReplaySubject<string>();
   private _deletedStream = new ReplaySubject<boolean>();
+  private _preventNavigationStream = new ReplaySubject<boolean>();
 
   constructor() {
     super();
@@ -43,5 +44,17 @@ export class ProjectDataSourceService extends DataSource<IReportDetails> {
 
   getDeletedStream(): Observable<boolean> {
     return this._deletedStream;
+  }
+
+  setPreventNavigationStream(prevent: boolean) {
+    this._preventNavigationStream.next(prevent);
+  }
+
+  getPreventNavigationStream(): Observable<boolean> {
+    return this._preventNavigationStream;
+  }
+
+  preventNavigationSelected() {
+    this.setPreventNavigationStream(true);
   }
 }


### PR DESCRIPTION
It is used in the backend to determine whether to navigate to the next after clicking the HTML element. It is because some events' dataLayer objects will be refreshed due to their nature such as `select_item` and `select_promotion`.